### PR TITLE
Add log viewer modal

### DIFF
--- a/ExportCheckoutBlazor/Pages/FetchData.razor
+++ b/ExportCheckoutBlazor/Pages/FetchData.razor
@@ -3,10 +3,12 @@
 @using System.Linq
 @using System.Net.Mail
 @using System.Globalization
+@using System.IO
 @using NDAProcesses.Services
 @using Microsoft.AspNetCore.Components.Forms
 @inject ExportService ExportSvc
 @inject SettingsService SettingsSvc
+@inject IWebHostEnvironment Env
 
 <style>
     /* Dark theme background */
@@ -69,6 +71,10 @@
         color: #a3be8c;
     }
 
+    .log-panel h4 {
+        color: #d08770;
+    }
+
     /* Form labels and text */
     .form-label, .form-text {
         color: #d8dee9;
@@ -107,6 +113,9 @@
         </button>
         <button class="btn btn-success open-btn" @onclick="() => ShowExportModal = true">
             📤 Custom Report
+        </button>
+        <button class="btn btn-secondary open-btn" @onclick="OpenLogModal">
+            📝 View Logs
         </button>
     </div>
 
@@ -263,10 +272,32 @@
 
 </div>
 
+@if (ShowLogModal)
+{
+    <div class="modal-overlay">
+        <div class="modal-content log-panel">
+            <button class="modal-close" @onclick="() => ShowLogModal = false">×</button>
+            <h4>Export Log</h4>
+            <input class="form-control mb-2" placeholder="Search..." @bind="LogFilter" />
+            <pre style="white-space: pre-wrap; max-height:400px; overflow:auto;">
+@foreach (var line in FilteredLogLines())
+{
+    @line
+    <br />
+}
+            </pre>
+        </div>
+    </div>
+}
+
 @code {
     // Modal toggles
     bool ShowSettingsModal;
     bool ShowExportModal;
+    bool ShowLogModal;
+
+    string[] LogLines = Array.Empty<string>();
+    string LogFilter = string.Empty;
 
     // ── Export UI state ─────────────────────────────────────────────────────────
     List<string> PresetEmailOptions { get; set; } = new()
@@ -421,4 +452,17 @@
         SettingsSvc.Save();
         ScheduleMessage = "✅ Settings saved!";
     }
+
+    void OpenLogModal()
+    {
+        var logPath = Path.Combine(Env.ContentRootPath, "Logs", "ExportCheckoutReport.log");
+        LogLines = File.Exists(logPath) ? File.ReadAllLines(logPath) : Array.Empty<string>();
+        LogFilter = string.Empty;
+        ShowLogModal = true;
+    }
+
+    IEnumerable<string> FilteredLogLines() =>
+        string.IsNullOrWhiteSpace(LogFilter)
+            ? LogLines
+            : LogLines.Where(l => l.Contains(LogFilter, StringComparison.OrdinalIgnoreCase));
 }

--- a/ExportCheckoutBlazor/Pages/LogViewer.razor
+++ b/ExportCheckoutBlazor/Pages/LogViewer.razor
@@ -1,0 +1,27 @@
+@page "/log"
+@using System.IO
+@inject IWebHostEnvironment Env
+
+<h3>Export Log</h3>
+
+@if (LogContent == null)
+{
+    <p><em>No log file found.</em></p>
+}
+else
+{
+    <pre style="white-space: pre-wrap">@LogContent</pre>
+}
+
+@code {
+    private string? LogContent;
+
+    protected override void OnInitialized()
+    {
+        var logPath = Path.Combine(Env.ContentRootPath, "Logs", "ExportCheckoutReport.log");
+        if (File.Exists(logPath))
+        {
+            LogContent = File.ReadAllText(logPath);
+        }
+    }
+}

--- a/ExportCheckoutBlazor/Program.cs
+++ b/ExportCheckoutBlazor/Program.cs
@@ -7,6 +7,13 @@ using System.IO;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Extend server timeouts so the Blazor Server app does not disconnect
+builder.WebHost.ConfigureKestrel(opt =>
+{
+    opt.Limits.KeepAliveTimeout = TimeSpan.FromDays(7);
+    opt.Limits.RequestHeadersTimeout = TimeSpan.FromDays(7);
+});
+
 // 1) Load configuration first so SettingsService picks up the correct values
 builder.Configuration
     .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
@@ -21,7 +28,12 @@ builder.Services.AddScoped<ExportService>();
 
 // 4) Blazor Server setup
 builder.Services.AddRazorPages();
-builder.Services.AddServerSideBlazor();
+builder.Services.AddServerSideBlazor()
+    .AddCircuitOptions(opts =>
+    {
+        // Hold disconnected circuits for a long time so the app never times out
+        opts.DisconnectedCircuitRetentionPeriod = TimeSpan.FromDays(7);
+    });
 
 var app = builder.Build();
 
@@ -39,6 +51,15 @@ app.UseStaticFiles(new StaticFileOptions
 {
     FileProvider = new PhysicalFileProvider(exportDir),
     RequestPath  = "/exports"
+});
+
+// expose the "Logs" folder at "/logs"
+var logsDir = Path.Combine(app.Environment.ContentRootPath, "Logs");
+Directory.CreateDirectory(logsDir);
+app.UseStaticFiles(new StaticFileOptions
+{
+    FileProvider = new PhysicalFileProvider(logsDir),
+    RequestPath  = "/logs"
 });
 
 app.UseRouting();

--- a/ExportCheckoutBlazor/Shared/NavMenu.razor
+++ b/ExportCheckoutBlazor/Shared/NavMenu.razor
@@ -24,6 +24,11 @@
                 <span class="oi oi-list-rich" aria-hidden="true"></span> Fetch data
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="log">
+                <span class="oi oi-document" aria-hidden="true"></span> Log
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/ExportCheckoutBlazor/web.config
+++ b/ExportCheckoutBlazor/web.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <location path="." inheritInChildApplications="false">
+    <system.webServer>
+      <handlers>
+        <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
+      </handlers>
+      <aspNetCore processPath="dotnet" arguments=".\NDAProcesses.dll" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" hostingModel="inprocess" requestTimeout="00:00:00" />
+    </system.webServer>
+  </location>
+</configuration>

--- a/IIS_SETUP.md
+++ b/IIS_SETUP.md
@@ -1,0 +1,16 @@
+# IIS Configuration for Persistent Blazor Server
+
+The included `web.config` disables ASP.NET Core request timeouts so the site won't disconnect during long operations.
+
+1. **Deploy `web.config`**
+   - Copy `ExportCheckoutBlazor/web.config` to the website root on the IIS server.
+   - Ensure the path in `stdoutLogFile` exists or adjust it.
+
+2. **Application Pool Settings**
+   - In IIS Manager, select the application pool for this site.
+   - Set **Idle Time-out (minutes)** to `0` to prevent the app pool from stopping after periods of inactivity.
+   - Optionally disable **Ping Enabled** or raise **Ping Maximum Response Time** to avoid worker process recycling.
+
+3. **Additional Considerations**
+   - If using a proxy or load balancer in front of IIS, verify its request timeout settings are also increased or disabled.
+   - The server's firewall or network appliances should allow long-lived connections if SignalR is used.


### PR DESCRIPTION
## Summary
- add a **View Logs** button on the main dashboard
- open logs in a modal window with a search field
- configure the server to avoid timeouts when hosted on IIS
- document IIS settings for long-running Blazor Server apps

## Testing
- `dotnet build NDAProcesses.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6880c1e2b994832988dc5e108533f57b